### PR TITLE
docs: add README with build instructions + MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Dylan Jones
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# MorseGen
+
+MorseGen is a small SDL2-based program that repeatedly sends a fixed Morse code message through the computer's audio output. It demonstrates basic audio generation and event handling with SDL.
+
+## Build
+
+### Linux
+```bash
+make
+```
+
+### Windows
+```bash
+make -f Makefile.win
+```
+
+## Controls
+- Press `Esc` or close the window to stop playback.
+- Press `Ctrl+C` in the terminal to exit immediately.
+
+## Roadmap
+- Allow configuring the message and tone parameters.
+- Support real-time keyboard input for custom messages.
+- Provide a simple graphical interface.


### PR DESCRIPTION
## Summary
- add README with project overview, build instructions, controls, and roadmap
- add MIT license for Dylan Jones

## Testing
- `make` *(fails: Package fftw3 not found)*
- `make -f Makefile.win` *(fails: Makefile.win: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a50b4c5c832684db99d900f31b01